### PR TITLE
zebra: Cleanup the mac & neigh entry on vni transition(l2->l3)

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2357,8 +2357,8 @@ static int zebra_vxlan_handle_vni_transition(struct zebra_vrf *zvrf, vni_t vni,
 		/* Delete EVPN from BGP. */
 		zebra_evpn_send_del_to_client(zevpn);
 
-		zebra_evpn_neigh_del_all(zevpn, 0, 0, DEL_ALL_NEIGH);
-		zebra_evpn_mac_del_all(zevpn, 0, 0, DEL_ALL_MAC);
+		zebra_evpn_neigh_del_all(zevpn, 1, 0, DEL_ALL_NEIGH);
+		zebra_evpn_mac_del_all(zevpn, 1, 0, DEL_ALL_MAC);
 
 		/* Free up all remote VTEPs, if any. */
 		zebra_evpn_vtep_del_all(zevpn, 1);


### PR DESCRIPTION
    Testing Done:  verified the changes.

    RCA/Fix:

    During processing VNI transitions from L2 to L3 the entry was cleaned
    up in zebra but since the uninstall arg was unset the dataplane
    notification was missed.

    Fix this by calling del neigh and mac with the uninstall set to true.